### PR TITLE
Change Bedrock region to Tokyo

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -17,7 +17,7 @@
         ]
     },
     "context": {
-        "modelRegion": "us-east-1",
+        "modelRegion": "ap-northeast-1",
         "modelId": "anthropic.claude-3-sonnet-20240229-v1:0",
         "summarizers": {
             "AwsSolutionsArchitectEnglish": {


### PR DESCRIPTION
Fixes #4

Update the Bedrock region to Tokyo in `cdk.json`.

* Change the `modelRegion` value from `us-east-1` to `ap-northeast-1` under the `context` key.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/niwanowa/whats-new-summary-notifier/pull/5?shareId=4b693656-80d1-41e5-8eb2-8e929c348953).