### PR TITLE
notifiersを追加してみることで挙動を調査

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -44,6 +44,21 @@
                 "month": "*",
                 "year": "*"
                 }
+            },
+            "hugo": {
+                "destination": "slack",
+                "summarizerName": "AwsSolutionsArchitectJapanese",
+                "webhookUrlParameterName": "/hugo/URL",
+                "rssUrl": {
+                    "hugo": "https://aws.amazon.com/about-aws/whats-new/recent/feed/"
+                },
+                "schedule": {
+                "minute": "0/15",
+                "hour": "*",
+                "day": "*",
+                "month": "*",
+                "year": "*"
+                }
             }
         },
         "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,


### PR DESCRIPTION
This pull request includes a change to the `cdk.json` file to add a new configuration for the `hugo` summarizer. The change specifies the destination, summarizer name, webhook URL parameter, RSS URL, and schedule for the new summarizer.

Configuration additions:

* [`cdk.json`](diffhunk://#diff-6f34e8f9537aedd57eb30591cd562652dd2b7a8c26b4d50b22df2dfbf294a73fR47-R61): Added configuration for the `hugo` summarizer, including destination (`slack`), summarizer name (`AwsSolutionsArchitectJapanese`), webhook URL parameter name (`/hugo/URL`), RSS URL, and schedule.