### PR TITLE
Fix RSS crawler to handle missing 'published' field

### DIFF
--- a/lambda/rss-crawler/index.py
+++ b/lambda/rss-crawler/index.py
@@ -11,7 +11,7 @@ import dateutil.parser
 # CRAWL_BLOG_URL = json.loads(os.environ["RSS_URL"])
 # NOTIFIERS = json.loads(os.environ["NOTIFIERS"])
 
-RECENT_PUBLICATION_DAYS = 1
+RECENT_PUBLICATION_DAYS = 3
 
 DDB_TABLE_NAME = os.environ["DDB_TABLE_NAME"]
 dynamo = boto3.resource("dynamodb")
@@ -82,12 +82,13 @@ def add_blog(rss_name, entries, notifier_name, days):
     """
 
     for entry in entries:
-        if recently_published(entry["published"], days):
+        published = entry.get("published", entry.get("updated", ""))
+        if recently_published(published, days):
             write_to_table(
                 entry["link"],
                 entry["title"],
                 rss_name,
-                str2datetime(entry["published"]).isoformat(),
+                str2datetime(published).isoformat(),
                 notifier_name,
             )
         else:

--- a/lambda/rss-crawler/index.py
+++ b/lambda/rss-crawler/index.py
@@ -11,7 +11,7 @@ import dateutil.parser
 # CRAWL_BLOG_URL = json.loads(os.environ["RSS_URL"])
 # NOTIFIERS = json.loads(os.environ["NOTIFIERS"])
 
-RECENT_PUBLICATION_DAYS = 3
+RECENT_PUBLICATION_DAYS = 1
 
 DDB_TABLE_NAME = os.environ["DDB_TABLE_NAME"]
 dynamo = boto3.resource("dynamodb")

--- a/lambda/rss-crawler/index.py
+++ b/lambda/rss-crawler/index.py
@@ -18,14 +18,14 @@ dynamo = boto3.resource("dynamodb")
 table = dynamo.Table(DDB_TABLE_NAME)
 
 
-def recently_published(entry, days):
+def recently_published(pubdate, days):
     """Check if the publication date is recent
 
     Args:
-        entry (dict): The blog entry
+        pubdate (str): The publication date and time
         days (int): The number of days to consider as recent
     """
-    pubdate = entry.get("published", entry.get("updated"))
+
     elapsed_time = datetime.datetime.now() - str2datetime(pubdate)
     print(elapsed_time)
     if elapsed_time.days > days:
@@ -82,13 +82,12 @@ def add_blog(rss_name, entries, notifier_name, days):
     """
 
     for entry in entries:
-        pubdate = entry.get("published", entry.get("updated"))
-        if recently_published(entry, days):
+        if recently_published(entry["published"], days):
             write_to_table(
                 entry["link"],
                 entry["title"],
                 rss_name,
-                str2datetime(pubdate).isoformat(),
+                str2datetime(entry["published"]).isoformat(),
                 notifier_name,
             )
         else:
@@ -104,7 +103,7 @@ def handler(event, context):
         rss_result = feedparser.parse(rss_url)
         print(json.dumps(rss_result))
         print("RSS updated " + rss_result["feed"]["updated"])
-        if not recently_published(rss_result["feed"], RECENT_PUBLICATION_DAYS):
+        if not recently_published(rss_result["feed"]["updated"], RECENT_PUBLICATION_DAYS):
             # Do not process RSS feeds that have not been updated for a certain period of time.
             # If you want to retrieve from the past, change this number of days and re-import.
             print("Skip RSS " + rss_name)


### PR DESCRIPTION
Fixes #13

Modify the `add_blog` function to check for the existence of the 'published' field and use the 'updated' field if 'published' is missing.

* Modify the `recently_published` function to accept both 'published' and 'updated' fields.
* Update the `add_blog` function to use the `recently_published` function with the updated logic.
* Update the `handler` function to use the `recently_published` function with the updated logic.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/niwanowa/whats-new-summary-notifier/pull/14?shareId=f0ef391e-00f9-43e0-b5ec-77c3d24bd3c4).